### PR TITLE
feat: centralize JWT secret

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -35,6 +35,9 @@ const schemaPath = join(process.cwd(), "src", "schema.sql");
 const schema = readFileSync(schemaPath, "utf8");
 db.exec(schema);
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) throw new Error("JWT_SECRET is required");
+
 // --- Auth Middleware
 const authenticateToken = (req: any, res: any, next: any) => {
   const authHeader = req.headers['authorization'];
@@ -44,7 +47,7 @@ const authenticateToken = (req: any, res: any, next: any) => {
     return res.sendStatus(401);
   }
 
-  jwt.verify(token, process.env.JWT_SECRET!, (err: any, user: any) => {
+  jwt.verify(token, JWT_SECRET, (err: any, user: any) => {
     if (err) return res.sendStatus(403);
     req.user = user;
     next();
@@ -112,7 +115,7 @@ app.post('/api/auth/register', validateRequest(registerUserSchema), async (req, 
     `).run(userId, email, username, passwordHash, now, now);
 
     // Generate JWT
-    const token = jwt.sign({ userId, email, username }, process.env.JWT_SECRET!, { expiresIn: '7d' });
+    const token = jwt.sign({ userId, email, username }, JWT_SECRET, { expiresIn: '7d' });
 
     res.json({ token, user: { id: userId, email, username } });
   } catch (error) {
@@ -137,7 +140,7 @@ app.post('/api/auth/login', validateRequest(loginUserSchema), async (req, res, n
       return res.status(401).json({ error: 'Invalid credentials' });
     }
 
-    const token = jwt.sign({ userId: user.id, email: user.email, username: user.username }, process.env.JWT_SECRET!, { expiresIn: '7d' });
+    const token = jwt.sign({ userId: user.id, email: user.email, username: user.username }, JWT_SECRET, { expiresIn: '7d' });
 
     res.json({ token, user: { id: user.id, email: user.email, username: user.username } });
   } catch (error) {


### PR DESCRIPTION
### **User description**
## Summary
- load JWT secret once and error when missing
- reuse JWT secret constant for verifying and signing tokens

## Testing
- `JWT_SECRET=secret npm test --workspace=backend` *(fails: TypeError: Cannot read properties of undefined (reading 'replaceAll'))*

------
https://chatgpt.com/codex/tasks/task_e_68b2739f591883289fa9cd24d40d58df


___

### **PR Type**
Enhancement


___

### **Description**
- Centralize JWT secret loading with validation

- Replace direct environment variable access with constant

- Add startup error for missing JWT_SECRET


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Load JWT_SECRET"] --> B["Validate Secret Exists"]
  B --> C["Use in Auth Middleware"]
  B --> D["Use in Register Endpoint"]
  B --> E["Use in Login Endpoint"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.ts</strong><dd><code>Centralize JWT secret management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/server.ts

<ul><li>Load <code>JWT_SECRET</code> environment variable once at startup<br> <li> Add validation to throw error if <code>JWT_SECRET</code> is missing<br> <li> Replace direct <code>process.env.JWT_SECRET!</code> calls with <code>JWT_SECRET</code> constant<br> <li> Update authentication middleware and auth endpoints to use centralized <br>constant</ul>


</details>


  </td>
  <td><a href="https://github.com/sinsweatpants/Ara-Screenplay-IDE/pull/3/files#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aa">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

