### PR TITLE
Rename application to 'the-copy'

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,5 @@
 repository:
-  name: Ara-Screenplay-IDE
+  name: the-copy
 
 branches:
   - name: main

--- a/AUTH_TEST.md
+++ b/AUTH_TEST.md
@@ -3,4 +3,4 @@
 This file was created to test GitHub authentication with account: sinsweatpants
 
 Date: 2025-09-12
-Repository: Ara-Screenplay-IDE
+Repository: the-copy

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-
-# توثيق مشروع Ara-Screenplay-IDE
+# توثيق مشروع the-copy
 
 ## ١. نظرة عامة
 
-مشروع **Ara-Screenplay-IDE** هو بيئة تطوير متكاملة (IDE) مخصصة لكتابة وتحليل السيناريوهات باللغة العربية، بواجهة حديثة تعتمد على **React + Vite** للـ Frontend، و **Node.js + Express + PostgreSQL** للـ Backend.
+مشروع **the-copy** هو بيئة تطوير متكاملة (IDE) مخصصة لكتابة وتحليل السيناريوهات باللغة العربية، بواجهة حديثة تعتمد على **React + Vite** للـ Frontend، و **Node.js + Express + PostgreSQL** للـ Backend.
 المشروع يهدف إلى توفير أدوات قوية للكتاب والمطورين لإدارة النصوص، إجراء تحليلات باستخدام نماذج لغوية (LLM)، ودعم عمليات النشر والتشغيل في بيئة إنتاج آمنة.
 
 ---
@@ -24,8 +23,8 @@
 ### خطوات التثبيت محليًا
 
 ```bash
-git clone https://github.com/sinsweatpants/Ara-Screenplay-IDE.git
-cd Ara-Screenplay-IDE
+git clone https://github.com/sinsweatpants/the-copy.git
+cd the-copy
 npm ci
 ```
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>Arabic Screenplay IDE</title>
+    <title>the copy</title>
   </head>
   <body class="bg-slate-50">
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "screenplay-frontend",
+  "name": "the-copy",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Arabic Screenplay Writing Application</title>
+    <title>the copy</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
This commit renames the application from "screenplay-frontend" and "Arabic Screenplay IDE" to "the-copy".

The following files were updated:
- frontend/package.json: Changed the "name" field.
- frontend/index.html: Changed the <title> tag.
- index.html: Changed the <title> tag.
- .github/settings.yml: Changed the repository name.
- README.md: Updated all occurrences of the old name.
- AUTH_TEST.md: Updated the repository name.