### PR TITLE
feat: integrate editor utilities and gemini auditing

### DIFF
--- a/frontend/reports/FunctionMigrationReport.json
+++ b/frontend/reports/FunctionMigrationReport.json
@@ -1,0 +1,46 @@
+{
+  "from_file": "collated_functions.txt",
+  "functions_total": 76,
+  "functions_transferred": 20,
+  "untransferred": [
+    "addToRemoveQueue","AiFeatureSection","onSubmit","applyFormatToCurrentLine","ArabicQuillPage","calculateStats","Calendar","ChartStyle","closeAllMenus","createNewDocument","dispatch","FeaturesSection","Footer","formatText","genId","getEditorContent","getPayloadConfigFromPayload","handleClickOutside","handleSend","Header","handleSignIn","handleSignOut","HeroSection","Home","initMonaco","loadSampleText","Logo","markLineAsModified","MenubarGroup","MenubarMenu","MenubarPortal","MenubarRadioGroup","MenubarShortcut","MenubarSub","normalizeExistingContent","content","onChange","ProductionFeaturesSection","renderContent","renderMarkdown","ResultsDisplay","RootLayout","setEditorContent","splitLines","SwarmDialogueDisplay","update","dismiss","Toaster","updateCursorPosition","useCarousel","useChart","useFormField","useIsMobile","useSidebar","useToast","WritingToolsSection"
+  ],
+  "duplicates": {
+    "applyFormatToCurrentLine": [144, 174, 1801],
+    "auditWithGemini": [244, 2101],
+    "classifyLineInstantly": [435, 1998],
+    "formatText": [598, 1830],
+    "getMarginTop": [634, 1554],
+    "insertProcessedIntoDOM": [920, 1706],
+    "mapModelOutputToFormat": [1003, 2054],
+    "markLineAsModified": [1015, 2247],
+    "needsEmptyLine": [1086, 1579],
+    "normalizeSpacing": [1219, 1677],
+    "queueForGeminiReview": [1287, 2133],
+    "startBackgroundAuditor": [2184, 2397],
+    "stopBackgroundAuditor": [2239, 2453]
+  },
+  "rename_map": {},
+  "file_map": {
+    "classifyLineInstantly": "frontend/src/lib/editor/format.ts",
+    "getNextFormatOnEnter": "frontend/src/lib/editor/format.ts",
+    "normalizeSpacing": "frontend/src/lib/editor/format.ts",
+    "needsEmptyLine": "frontend/src/lib/editor/format.ts",
+    "getMarginTop": "frontend/src/lib/editor/format.ts",
+    "mapModelOutputToFormat": "frontend/src/lib/editor/format.ts",
+    "getClipboardText": "frontend/src/lib/editor/dom.ts",
+    "insertProcessedIntoDOM": "frontend/src/lib/editor/dom.ts",
+    "insertFragment": "frontend/src/lib/editor/dom.ts",
+    "buildAuditPrompt": "frontend/src/lib/editor/gemini.ts",
+    "auditWithGemini": "frontend/src/lib/editor/gemini.ts",
+    "queueForGeminiReview": "frontend/src/lib/editor/gemini.ts",
+    "startBackgroundAuditor": "frontend/src/lib/editor/gemini.ts",
+    "stopBackgroundAuditor": "frontend/src/lib/editor/gemini.ts"
+  },
+  "tests_added": [
+    "frontend/src/lib/editor/__tests__/format.test.ts",
+    "frontend/src/lib/editor/__tests__/dom.test.ts",
+    "frontend/src/lib/editor/__tests__/gemini.test.ts"
+  ],
+  "notes": "mapModelOutputToFormat and background auditor functions implemented; other collated utilities deferred."
+}

--- a/frontend/src/components/editor-toolbar.tsx
+++ b/frontend/src/components/editor-toolbar.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface Props {
+  auditing: boolean;
+  rulerVisible: boolean;
+  onToggleGemini: () => void;
+  onToggleRuler: () => void;
+}
+
+const EditorToolbar: React.FC<Props> = ({ auditing, rulerVisible, onToggleGemini, onToggleRuler }) => (
+  <div className="flex gap-2 mb-2 text-sm">
+    <button type="button" className="px-2 border">B</button>
+    <button type="button" className="px-2 border">I</button>
+    <button type="button" className="px-2 border">U</button>
+    <button type="button" className="px-2 border" onClick={onToggleRuler}>
+      {rulerVisible ? 'إخفاء المسطرة' : 'إظهار المسطرة'}
+    </button>
+    <button type="button" className="px-2 border" onClick={onToggleGemini}>
+      {auditing ? 'إيقاف Gemini' : 'تشغيل Gemini'}
+    </button>
+  </div>
+);
+
+export default EditorToolbar;

--- a/frontend/src/components/ruler.tsx
+++ b/frontend/src/components/ruler.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Props {
+  visible: boolean;
+}
+
+const Ruler: React.FC<Props> = ({ visible }) => {
+  if (!visible) return null;
+  const marks = Array.from({ length: 20 }, (_, i) => i + 1);
+  return (
+    <div className="flex text-xs text-gray-400 select-none mb-1">
+      {marks.map(n => (
+        <span key={n} className="w-8 text-center border-r">
+          {n}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default Ruler;

--- a/frontend/src/components/screenplay-editor.tsx
+++ b/frontend/src/components/screenplay-editor.tsx
@@ -7,11 +7,18 @@ import {
   ProcessedLine
 } from '../lib/editor/format';
 import { getClipboardText, insertProcessedIntoDOM } from '../lib/editor/dom';
+import { auditWithGemini, queueForGeminiReview } from '../lib/editor/gemini';
+import EditorToolbar from './editor-toolbar';
+import Ruler from './ruler';
+import { toast } from '../lib/toast';
 
 const ScreenplayEditor: React.FC = () => {
   const editorRef = useRef<HTMLDivElement>(null);
   const [currentFormat, setCurrentFormat] = useState<ScreenplayFormat>('action');
   const [stats, setStats] = useState({ characters: 0, words: 0, scenes: 0, pages: 1 });
+  const [isAuditing, setIsAuditing] = useState(false);
+  const [rulerVisible, setRulerVisible] = useState(true);
+  const lastModifiedLines = useRef<Set<number>>(new Set());
 
   const updateStats = () => {
     if (!editorRef.current) return;
@@ -22,20 +29,45 @@ const ScreenplayEditor: React.FC = () => {
     setStats({ characters, words, scenes, pages: 1 });
   };
 
-  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+  const processGeminiItems = async (items: any[]) => {
+    const batch = items.map((it: any) => ({ index: Number(it.lineIndex), raw: it.content, cls: it.format }));
+    const corrections = await auditWithGemini(batch, toast);
+    corrections.forEach(c => {
+      const el = editorRef.current?.querySelector(`div[data-line-index="${c.index}"]`) as HTMLElement | null;
+      if (el) {
+        el.className = c.suggestedClass;
+        el.classList.add('bg-yellow-100');
+        setTimeout(() => el.classList.remove('bg-yellow-100'), 500);
+        lastModifiedLines.current.add(c.index);
+      }
+    });
+  };
+
+  const handlePaste = async (e: React.ClipboardEvent<HTMLDivElement>) => {
     e.preventDefault();
     const text = getClipboardText(e);
     if (!text || !editorRef.current) return;
     const lines = text.split(/\r?\n/);
     let prev: ScreenplayFormat = currentFormat;
-    const processed: ProcessedLine[] = lines.map((raw) => {
+    const processed: ProcessedLine[] = lines.map(raw => {
       const fmt = classifyLineInstantly(raw, prev);
       prev = fmt;
       return { content: raw, format: fmt, isHtml: false };
     });
     const normalized = normalizeSpacing(processed);
-    const { html } = insertProcessedIntoDOM(normalized);
+    const { html, batchLinesForAudit } = insertProcessedIntoDOM(normalized);
     editorRef.current.innerHTML = html;
+    if (isAuditing) {
+      batchLinesForAudit.forEach(({ index, raw, cls }) => {
+        const element = editorRef.current?.querySelector(`div[data-line-index="${index}"]`) as HTMLElement | null;
+        if (element) {
+          queueForGeminiReview(
+            { element, content: raw, format: cls, timestamp: Date.now(), lineIndex: String(index) },
+            processGeminiItems
+          );
+        }
+      });
+    }
     updateStats();
   };
 
@@ -51,8 +83,23 @@ const ScreenplayEditor: React.FC = () => {
     }
   };
 
+  const toggleGemini = () => {
+    if (!import.meta.env.VITE_GEMINI_API_KEY) {
+      toast('مفتاح Gemini غير موجود');
+      return;
+    }
+    setIsAuditing(v => !v);
+  };
+
   return (
     <div className="p-4" dir="rtl">
+      <EditorToolbar
+        auditing={isAuditing}
+        rulerVisible={rulerVisible}
+        onToggleGemini={toggleGemini}
+        onToggleRuler={() => setRulerVisible(r => !r)}
+      />
+      <Ruler visible={rulerVisible} />
       <div className="mb-2 text-sm text-gray-500">التنسيق الحالي: {currentFormat}</div>
       <div
         ref={editorRef}

--- a/frontend/src/components/ui/dialog-header.tsx
+++ b/frontend/src/components/ui/dialog-header.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DialogHeader: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <div className="text-lg font-bold mb-2">{children}</div>
+);
+
+export default DialogHeader;

--- a/frontend/src/components/ui/dropdown-menu-shortcut.tsx
+++ b/frontend/src/components/ui/dropdown-menu-shortcut.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DropdownMenuShortcut: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <span className="ml-auto pl-4 text-xs text-muted-foreground">{children}</span>
+);
+
+export default DropdownMenuShortcut;

--- a/frontend/src/lib/editor/__tests__/dom.test.ts
+++ b/frontend/src/lib/editor/__tests__/dom.test.ts
@@ -1,0 +1,20 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { insertProcessedIntoDOM } from '../dom';
+import { ProcessedLine } from '../format';
+
+describe('insertProcessedIntoDOM', () => {
+  it('creates html with correct classes', () => {
+    const lines: ProcessedLine[] = [
+      { content: 'وصف', format: 'action', isHtml: false },
+      { content: 'علي', format: 'character', isHtml: false },
+      { content: 'مرحبا', format: 'dialogue', isHtml: false }
+    ];
+    const { html, batchLinesForAudit } = insertProcessedIntoDOM(lines);
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    expect(doc.body.children).toHaveLength(3);
+    expect(doc.body.children[1].className).toBe('character');
+    expect(batchLinesForAudit.length).toBe(3);
+  });
+});

--- a/frontend/src/lib/editor/__tests__/format.test.ts
+++ b/frontend/src/lib/editor/__tests__/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { classifyLineInstantly, getNextFormatOnEnter } from '../format';
+import {
+  classifyLineInstantly,
+  getNextFormatOnEnter,
+  needsEmptyLine,
+  getMarginTop,
+  normalizeSpacing,
+  ProcessedLine
+} from '../format';
 
 describe('classifyLineInstantly', () => {
   it('detects scene headers', () => {
@@ -16,5 +23,26 @@ describe('getNextFormatOnEnter', () => {
   });
   it('dialogue to action', () => {
     expect(getNextFormatOnEnter('dialogue')).toBe('action');
+  });
+});
+
+describe('needsEmptyLine and getMarginTop', () => {
+  it('detects need for empty line between action and character', () => {
+    expect(needsEmptyLine('action', 'character')).toBe(true);
+  });
+  it('returns spacing value', () => {
+    expect(getMarginTop('action', 'character')).toBe('1em');
+  });
+});
+
+describe('normalizeSpacing', () => {
+  it('inserts empty lines when needed', () => {
+    const lines: ProcessedLine[] = [
+      { content: 'وصف', format: 'action', isHtml: false },
+      { content: 'علي', format: 'character', isHtml: false }
+    ];
+    const normalized = normalizeSpacing(lines);
+    expect(normalized).toHaveLength(3);
+    expect(normalized[1].isEmpty).toBe(true);
   });
 });

--- a/frontend/src/lib/editor/__tests__/gemini.test.ts
+++ b/frontend/src/lib/editor/__tests__/gemini.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { auditWithGemini, buildAuditPrompt } from '../gemini';
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('auditWithGemini', () => {
+  it('warns when key missing', async () => {
+    vi.stubEnv('VITE_GEMINI_API_KEY', '');
+    const toast = vi.fn();
+    const res = await auditWithGemini([{ index: 0, raw: 'hi', cls: 'action' }], toast);
+    expect(res).toEqual([]);
+    expect(toast).toHaveBeenCalled();
+  });
+
+  it('returns corrections from API', async () => {
+    vi.stubEnv('VITE_GEMINI_API_KEY', 'key');
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          { content: { parts: [{ text: '[{"index":0,"suggestedClass":"dialogue","reason":"x"}]' }] } }
+        ]
+      })
+    }) as any;
+    const res = await auditWithGemini([{ index: 0, raw: 'hi', cls: 'action' }]);
+    expect(res[0].suggestedClass).toBe('dialogue');
+  });
+});
+
+describe('buildAuditPrompt', () => {
+  it('includes data in prompt', () => {
+    const prompt = buildAuditPrompt([{ index: 1, raw: 'test', cls: 'action' }]);
+    expect(prompt).toContain('test');
+  });
+});

--- a/frontend/src/lib/editor/format.ts
+++ b/frontend/src/lib/editor/format.ts
@@ -60,3 +60,21 @@ export const normalizeSpacing = (
 
   return normalized;
 };
+export const mapModelOutputToFormat = (
+  modelResult: { label: string; score: number }[],
+  text: string,
+  context: { previousFormat: ScreenplayFormat }
+): ScreenplayFormat => {
+  const base = classifyLineInstantly(text, context.previousFormat);
+  const top = modelResult[0];
+  if (top?.score > 0.8) {
+    const label = top.label.toLowerCase();
+    if (label.includes('dialogue') || label.includes('conversation')) return 'dialogue';
+    if (label.includes('action') || label.includes('description')) return 'action';
+  }
+  if (
+    ['character', 'scene-header-1', 'scene-header-2', 'scene-header-3', 'transition'].includes(base)
+  )
+    return base;
+  return base;
+};

--- a/frontend/src/lib/editor/gemini.ts
+++ b/frontend/src/lib/editor/gemini.ts
@@ -80,3 +80,16 @@ export const queueForGeminiReview = (
     await process(items);
   }, 2000);
 };
+let auditorId: number | null = null;
+
+export const startBackgroundAuditor = (fn: () => Promise<void>, interval = 10000) => {
+  stopBackgroundAuditor();
+  auditorId = window.setInterval(fn, interval);
+};
+
+export const stopBackgroundAuditor = () => {
+  if (auditorId) {
+    clearInterval(auditorId);
+    auditorId = null;
+  }
+};

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -1,0 +1,7 @@
+export const toast = (msg: string) => {
+  const div = document.createElement('div');
+  div.textContent = msg;
+  div.className = 'fixed top-2 left-1/2 -translate-x-1/2 bg-black text-white px-4 py-2 rounded shadow z-50';
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 3000);
+};


### PR DESCRIPTION
## Summary
- add mapModelOutputToFormat and background Gemini auditing helpers
- build editor toolbar, ruler, and toast utilities
- expand tests for editor formatting and Gemini integration

## Testing
- `npm test --workspace=frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ab3a195083288f8ec97f86fa3d48